### PR TITLE
Fix loading package.json to find version

### DIFF
--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -36,6 +36,7 @@
 
 var console = require("console");
 var fs = require("fs");
+var path = require("path");
 
 var Kernel = require("jp-kernel");
 
@@ -177,7 +178,7 @@ function parseCommandArguments() {
     } else {
         nodeVersion = process.versions.node;
         protocolVersion = config.protocolVersion;
-        ijsVersion = JSON.parse(fs.readFileSync("package.json")).version;
+        ijsVersion = JSON.parse(fs.readFileSync(path.join(__dirname, ".." , "package.json"))).version;
         config.kernelInfoReply = {
             "protocol_version": protocolVersion,
             "implementation": "ijavascript",


### PR DESCRIPTION
In `lib/kernel.js`, line 183 tries to load ijavascript's `package.json` file to find the current version number. However, if $PWD isn't the ijavascript module folder, this will fail with a "file not found" error.

This commit changes that line so that it tries to load `__dirname/../package.json` (using the `path.join()` utility for cross-platform portability).
